### PR TITLE
Add missing FEC values & service type

### DIFF
--- a/autobouquetswiki.cpp
+++ b/autobouquetswiki.cpp
@@ -960,6 +960,10 @@ string get_fec(short modulation_system, short modulation_type, short fec_inner) 
 			case 3: fec = "3/4"; break;
 			case 4: fec = "5/6"; break;
 			case 5: fec = "7/8"; break;
+			case 6: fec = "8/9"; break;
+			case 7: fec = "3/5"; break;
+			case 8: fec = "4/5"; break;
+			case 9: fec = "9/10"; break;
 			default:
 				fec = "0/0"; break;
 		}

--- a/autobouquetswiki.cpp
+++ b/autobouquetswiki.cpp
@@ -358,7 +358,7 @@ int si_parse_nit(unsigned char *data, int length) {
 				Transport.symbol_rate += (data[offset2 + 10] & 0xf) * 1000;
 				Transport.symbol_rate += (data[offset2 + 11] >> 4) * 100;
 				Transport.symbol_rate += (data[offset2 + 11] & 0xf) * 10;
-				Transport.symbol_rate += data[offset2 + 11] >> 4;
+				Transport.symbol_rate += data[offset2 + 12] >> 4;
 				
 				Transport.fec_inner = data[offset2 + 12] & 0xf;
 

--- a/autobouquetswiki.cpp
+++ b/autobouquetswiki.cpp
@@ -929,6 +929,7 @@ string get_typename(short st) {
 		case 0x87: stn = "HD TV OnDemand"; break;
 		case 0x85: stn = "SD TV RedButton"; break;
 		case 0x82: stn = "DATA RedButton"; break;
+		case 0x89: stn = "HD TV RedButton"; break;
 
 		default:
 			stn = "User Defined"; break;


### PR DESCRIPTION
* Add missing FEC values, as defined in EN 300 468.
  - One of them, 8/9, was in use on 28.2°E.
  - Side note: I don't understand why there's a second branch here for DVB-S - I couldn't find any documentation of DVB-S being any different to DVB-S2 for FEC values - so I haven't touched that branch. Of the values that were different in this other branch, none were actually in use on Sky or Freesat so I couldn't even verify the differences.

* Add service type 0x89. This is HD red button - first spotted in late 2019.

* Fix a small error in reading the last digit of the symbol rate - it was reading the 3rd last digit instead.
  - This didn't really matter since no transponders on 28.2°E have a symbol rate where these digits are not zero but I fixed it nonetheless.